### PR TITLE
Fix duplicate button id and malformed attribute

### DIFF
--- a/Setup/index.html
+++ b/Setup/index.html
@@ -93,7 +93,7 @@
       transform: translate(-50%, -50%) scale(0.9);
     }
 
-    #toggleConfig {      
+    .config-button {
       top: 10px;
       left: 10px;
       background: rgba(0,0,0,0.6);
@@ -135,9 +135,9 @@
   </div>
 
   <div style="background: rgba(255,255,255,0.1); padding: 13px 12px; border-radius: 20px; backdrop-filter: blur(8px);">
-    <button id="toggleConfig" onclick="toggleConfig()">  הצג / הסתר תפריט  </button>	
-	<button id="toggleConfig" onclick="window.open('import_export.html', '_blank')" ">  ייבוא / ייצוא  </button>
-  </div>  
+    <button class="config-button" onclick="toggleConfig()">  הצג / הסתר תפריט  </button>
+    <button class="config-button" onclick="window.open('import_export.html', '_blank')">  ייבוא / ייצוא  </button>
+  </div>
 
 </div>
 

--- a/index.htm
+++ b/index.htm
@@ -94,7 +94,7 @@
       transform: translate(-50%, -50%) scale(0.9);
     }
 
-    #toggleConfig {      
+    .config-button {
       top: 10px;
       left: 10px;
       background: rgba(0,0,0,0.6);
@@ -136,8 +136,8 @@
   </div>
 
   <div style="background: rgba(255,255,255,0.1); padding: 13px 12px; border-radius: 20px; backdrop-filter: blur(8px);">
-    <button id="toggleConfig" onclick="toggleConfig()">  הצג / הסתר תפריט  </button>	
-	<button id="toggleConfig" onclick="window.open('import_export.html', '_blank')" ">  ייבוא / ייצוא  </button>
+    <button class="config-button" onclick="toggleConfig()">  הצג / הסתר תפריט  </button>
+    <button class="config-button" onclick="window.open('import_export.html', '_blank')">  ייבוא / ייצוא  </button>
   </div>  
 
 </div>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
       transform: translate(-50%, -50%) scale(0.9);
     }
 
-    #toggleConfig {      
+    .config-button {
       top: 10px;
       left: 10px;
       background: rgba(0,0,0,0.6);
@@ -136,9 +136,9 @@
   </div>
 
   <div style="background: rgba(255,255,255,0.1); padding: 13px 12px; border-radius: 20px; backdrop-filter: blur(8px);">
-    <button id="toggleConfig" onclick="toggleConfig()">  הצג / הסתר תפריט  </button>	
-	<button id="toggleConfig" onclick="window.open('import_export.html', '_blank')" ">  ייבוא / ייצוא  </button>
-  </div>  
+    <button class="config-button" onclick="toggleConfig()">  הצג / הסתר תפריט  </button>
+    <button class="config-button" onclick="window.open('import_export.html', '_blank')">  ייבוא / ייצוא  </button>
+  </div>
 
 </div>
 


### PR DESCRIPTION
## Summary
- ensure config buttons use a class instead of duplicated `id`
- fix malformed quotation in the Import/Export button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68526caaa6a0832c8a65b711889f84e1